### PR TITLE
OPTI-2652: ignore vehicleId skill in vehicleTypeKey

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleTypeKey.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleTypeKey.java
@@ -32,7 +32,7 @@ import java.util.*;
  */
 public class VehicleTypeKey extends AbstractVehicle.AbstractTypeKey {
 
-    private final static String VEHICLE_ID_SKILL_PREFIX = "#vehicleId#_";
+    private final static String VEHICLE_ID_SKILL_PREFIX = "#vehicle_id#_";
 
     public final String type;
     public final String startLocationId;
@@ -65,7 +65,7 @@ public class VehicleTypeKey extends AbstractVehicle.AbstractTypeKey {
     private Skills getSkillsWithoutVehicleId(Skills skills){
         final Set<String> skillsWithoutVehicleId = new HashSet<>();
         for (String skill : skills.values()) {
-            if (!skill.startsWith(VEHICLE_ID_SKILL_PREFIX)) {
+            if (!skill.toLowerCase().startsWith(VEHICLE_ID_SKILL_PREFIX)) {
                 skillsWithoutVehicleId.add(skill);
             }
         }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleTypeKey.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleTypeKey.java
@@ -19,12 +19,9 @@ package com.graphhopper.jsprit.core.problem.vehicle;
 
 import com.graphhopper.jsprit.core.problem.AbstractVehicle;
 import com.graphhopper.jsprit.core.problem.Skills;
+import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
-
+import java.util.*;
 
 /**
  * Key to identify similar vehicles
@@ -34,6 +31,8 @@ import java.util.Set;
  * @author stefan
  */
 public class VehicleTypeKey extends AbstractVehicle.AbstractTypeKey {
+
+    private final static String VEHICLE_ID_SKILL_PREFIX = "#vehicleId#_";
 
     public final String type;
     public final String startLocationId;
@@ -54,13 +53,23 @@ public class VehicleTypeKey extends AbstractVehicle.AbstractTypeKey {
         this.endLocationId = endLocationId;
         this.earliestStart = earliestStart;
         this.latestEnd = latestEnd;
-        this.skills = skills;
+        this.skills = getSkillsWithoutVehicleId(skills);
         this.returnToDepot = returnToDepot;
         this.userData = userData;
         this.earliestBreakStart = earliestBreakStart;
         this.latestBreakStart = latestBreakStart;
         this.breakDuration = breakDuration;
         this.prohibitedTasks.addAll(prohibitedTasks);
+    }
+
+    private Skills getSkillsWithoutVehicleId(Skills skills){
+        final Set<String> skillsWithoutVehicleId = new HashSet<>();
+        for (String skill : skills.values()) {
+            if (!skill.startsWith(VEHICLE_ID_SKILL_PREFIX)) {
+                skillsWithoutVehicleId.add(skill);
+            }
+        }
+        return Skills.Builder.newInstance().addAllSkills(skillsWithoutVehicleId).build();
     }
 
     public VehicleTypeKey(String typeId, String startLocationId, String endLocationId, double earliestStart, double latestEnd, Skills skills, Collection<String> prohibitedTasks, boolean returnToDepot, Object userData) {


### PR DESCRIPTION
VehicleTypeKey is used to compare between vehicles type of different vehicles in order to recognized 2 vehicles with same data (tw, skills, location.. etc) and improve the performance. VehicleTypeKey contains also the vehicle skills.

we add the vehicle id as a vehicle skill to all vehicles in order to support: 
1. assigned task per vehicle
2. vehicle multiple break
3. inactive task window

because we add the vehicle id as a vehicle skills, we made the VehicleTypeKey to become unique per each vehicle (as vehicle id is unique) and we affected on the optimization performance.

in order to avoid it, we will add a prefix ("#vehicle_id#_") to the vehicle id when added as a skill, and when we create the VehicleTypeKey we will filter any skills starts with this prefix.

